### PR TITLE
Terminate signal now properly handled

### DIFF
--- a/riggerlib/__init__.py
+++ b/riggerlib/__init__.py
@@ -728,6 +728,18 @@ class RiggerClient(object):
         except Exception:
             return None
 
+    def terminate(self):
+        headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+        try:
+            r = self._session.post("http://{}:{}/terminate/".format(self.address, self.port),
+                                   data={}, headers=headers)
+            resp = r.json()
+            return resp
+        except (requests.exceptions.ConnectionError):
+            return None
+        except Exception:
+            return None
+
 
 def shutdown():
     """

--- a/riggerlib/wsgi.py
+++ b/riggerlib/wsgi.py
@@ -20,7 +20,7 @@ def setup_zmq_socket():
     zmq_communicate('ping')
 
 
-@application.route('/terminate/')
+@application.route('/terminate/', methods=['GET', 'POST'])
 def terminate():
     zmq_communicate('shutdown')
     flask.abort('503')


### PR DESCRIPTION
If we do it this way, it's trivial to change the fire_hook call to be just .terminate() in the artifactor plugin.
